### PR TITLE
Fix date in name and header of file to fix sorting

### DIFF
--- a/content/signet/release-notes/20190110_signet-client-0.9.12-notes.md
+++ b/content/signet/release-notes/20190110_signet-client-0.9.12-notes.md
@@ -1,6 +1,6 @@
 ---
 title: Signet Client version 0.9.12
-date: "2018-01-10"
+date: "2019-01-10"
 ---
 
 ### New features


### PR DESCRIPTION
The release notes page was showing the latest release in the wrong location and the link on the Downloads page was invalid, it pointed to the actual date of 2019 while this file was named 2018 with the 2018 in the header.